### PR TITLE
Add format on save for go files

### DIFF
--- a/example.txtar
+++ b/example.txtar
@@ -15,8 +15,9 @@ package main
 import "fmt"
 
 func main() {
-    fmt.Println("Hello, world!")
+	fmt.Println("Hello, world!")
 }
+
 -- hello.tmpl --
 {{ "Hello, world!" }}
 -- hello.html --

--- a/extension.js
+++ b/extension.js
@@ -1,0 +1,113 @@
+const vscode = require('vscode');
+const cp = require('child_process');
+
+/**
+ * Activate the extension.
+ *
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+    // Register a formatter for the `testscript` language (txtar files)
+    const disposable = vscode.languages.registerDocumentFormattingEditProvider('testscript', {
+        provideDocumentFormattingEdits(document, options, token) {
+            return formatDocument(document);
+        },
+    });
+
+    context.subscriptions.push(disposable);
+}
+
+/**
+ * Deactivate the extension.
+ */
+function deactivate() {
+    // nothing to clean up
+}
+
+/**
+ * Format a txtar document by running `gofmt` over any embedded Go source files.
+ *
+ * @param {vscode.TextDocument} document
+ * @returns {vscode.TextEdit[]}
+ */
+function formatDocument(document) {
+    const edits = [];
+
+    const text = document.getText();
+    const lines = text.split(/\r?\n/);
+
+    // Regex that matches file delimiters like: `-- hello.go --`
+    const headerRE = /^--\s+(.+?)\s+--$/;
+
+    let currentFilename = null;
+    let blockStart = null; // line index where the file content starts
+
+    /**
+     * Flush a block (if any) and append edits.
+     * @param {number} endLine - index of the line BEFORE the next header (or EOF)
+     */
+    function flushBlock(endLine) {
+        if (currentFilename && currentFilename.endsWith('.go') && blockStart !== null) {
+            const originalRange = new vscode.Range(
+                blockStart,
+                0,
+                endLine,
+                lines[endLine] ? lines[endLine].length : 0,
+            );
+            const originalText = document.getText(originalRange);
+
+            const formattedText = runGofmt(originalText);
+            if (formattedText !== null && formattedText !== originalText) {
+                // Replace the original block with the formatted version.
+                edits.push(vscode.TextEdit.replace(originalRange, formattedText.replace(/\r?\n$/, '\n')));
+            }
+        }
+        // reset state
+        currentFilename = null;
+        blockStart = null;
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+        const m = lines[i].match(headerRE);
+        if (m) {
+            // When we hit a new header, flush any active block first.
+            if (blockStart !== null) {
+                flushBlock(i - 1);
+            }
+            // Start new block
+            currentFilename = m[1];
+            blockStart = i + 1; // content starts on next line
+        }
+    }
+    // flush the final block to EOF if needed
+    if (blockStart !== null) {
+        flushBlock(lines.length - 1);
+    }
+
+    return edits;
+}
+
+/**
+ * Run `go fmt` on a Go source string.
+ * Returns formatted source, or null on error.
+ * @param {string} source
+ * @returns {string|null}
+ */
+function runGofmt(source) {
+    try {
+        const result = cp.execFileSync('gofmt', [], {
+            input: source,
+            encoding: 'utf8',
+        });
+        return result;
+    } catch (err) {
+        // If gofmt fails (syntax errors, not installed, etc.) ignore formatting.
+        console.error('gofmt failed:', err.message || err);
+        return null;
+    }
+}
+
+module.exports = {
+    activate,
+    deactivate,
+}; 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+    "name": "vscode-testscript",
+    "version": "0.0.6",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "vscode-testscript",
+            "version": "0.0.6",
+            "engines": {
+                "vscode": "^1.62.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "repository": "https://github.com/twpayne/vscode-testscript",
     "publisher": "twpayne",
     "version": "0.0.6",
+    "main": "./extension.js",
+    "activationEvents": [
+        "onLanguage:testscript"
+    ],
     "engines": {
         "vscode": "^1.62.0"
     },


### PR DESCRIPTION
I have tested this by formatting all testscript files in garble: https://github.com/burrowers/garble/pull/957 